### PR TITLE
Update xbbg to 0.9.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - blpapi
     - numpy >=2.2.6
     - pandas >=2.0,<=2.3.0
-    - pandas-market-calendars >=5.1.3
+    - pandas_market_calendars >=5.1.3
     - pyarrow >=22.0.0
     - python-stdnum >=2.1
     - pytz >=2025.2
@@ -44,6 +44,7 @@ test:
     - pip check
   requires:
     - pip
+    - python {{ python_min }}
 
 about:
   home: https://github.com/alpha-xone/xbbg
@@ -57,3 +58,4 @@ about:
 extra:
   recipe-maintainers:
     - marcobonifacio
+    - kj55-dev

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "xbbg" %}
-{% set version = "0.7.9" %}
+{% set version = "0.9.0" %}
+{% set python_min = "3.10" %}
 
 package:
   name: {{ name|lower }}
@@ -7,29 +8,34 @@ package:
 
 source:
   url: https://github.com/alpha-xone/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: 59787a426df1d49c84ebe16775dfb757bfc47acdfcdf79c6464392ddaac55915
-
+  sha256: 856fb05f80ada823fd9b9e094a6a6d73e32817458b45c81d278a1faba3f63be0
 
 build:
   noarch: python
-  number: 1
-  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+  script:
+    - export SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}  # [unix]
+    - set SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}  # [win]
+    - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
-    - python {{ python_min }}
+    - python {{ python_min }}.*
     - pip
-    - pypandoc
-    - setuptools
+    - setuptools >=77
+    - setuptools_scm >=8
+    - wheel
   run:
     - python >={{ python_min }}
     - blpapi
-    - numpy >=1.15.0
-    - pandas >=1.0.0,<=1.5.3
-    - pyarrow >=1.0.1
-    - pytz >=2020.4
-    - ruamel.yaml >=0.15.0
-    - pytest
+    - numpy >=2.2.6
+    - pandas >=2.0,<=2.3.0
+    - pandas-market-calendars >=5.1.3
+    - pyarrow >=22.0.0
+    - python-stdnum >=2.1
+    - pytz >=2025.2
+    - ruamel.yaml >=0.18.16
+    - pytest >=8.4.2
 
 test:
   imports:
@@ -38,7 +44,6 @@ test:
     - pip check
   requires:
     - pip
-    - python {{ python_min }}
 
 about:
   home: https://github.com/alpha-xone/xbbg


### PR DESCRIPTION
## Summary
- Update xbbg from 0.7.9 to 0.9.0
- Add `python_min` variable set to 3.10 (matches upstream `requires-python = ">=3.10,<3.15"`)
- Add `SETUPTOOLS_SCM_PRETEND_VERSION` for proper version detection with GitHub tarball
- Update all dependencies to match upstream pyproject.toml
- Add new dependencies: `pandas-market-calendars`, `python-stdnum`
- Update host requirements for modern setuptools build

## Checklist
- [x] Used a fork of the feedstock to make changes
- [x] Bumped build number to 0 (new version)
- [x] License remains Apache-2.0

## Upstream changes (v0.9.0)
- Add `etf_holdings()` function for retrieving ETF holdings via BQL
- Add multi-day support to `bdib()`
- Add multi-day cache support for `bdib()`