### PR TITLE
Update xbbg to 1.1.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,27 +1,27 @@
 {% set name = "xbbg" %}
-{% set version = "1.1.0" %}
+{% set version = "1.1.1" %}
 {% set python_mm = python.split(" ")[0].replace(".*", "") %}
 {% set abi_tag = "cp" ~ python_mm.replace(".", "") %}
 {% set platform_tags = {"linux-64": "manylinux_2_34_x86_64", "osx-arm64": "macosx_11_0_universal2", "win-64": "win_amd64"} %}
 {% set wheel_filename = name ~ "-" ~ version ~ "-" ~ abi_tag ~ "-" ~ abi_tag ~ "-" ~ platform_tags[target_platform] ~ ".whl" %}
 {% set wheel_artifacts = {
   "linux-64": {
-    "3.10": {"url": "https://files.pythonhosted.org/packages/2b/bc/bca53c656bb6c90caeff67a7325146d9ced028f5f304e75b4a95a6992f88/xbbg-1.1.0-cp310-cp310-manylinux_2_34_x86_64.whl", "sha256": "67be551c438f83ea7165e690895004a192848d089c6849a1520c8a9eae3ee156"},
-    "3.11": {"url": "https://files.pythonhosted.org/packages/27/8a/5654fe907059bc654590bde1099dd2ab242d4e7921792e38d2f18156bdb9/xbbg-1.1.0-cp311-cp311-manylinux_2_34_x86_64.whl", "sha256": "7ecb466b1b4033bf7ebc3543838d8aeebad4c733c4913d61a88e83657748f095"},
-    "3.12": {"url": "https://files.pythonhosted.org/packages/4a/1f/89d4fc2ed8bce16c02e98065f96bd8936f65d0c42f28aead32d34d16aec5/xbbg-1.1.0-cp312-cp312-manylinux_2_34_x86_64.whl", "sha256": "2d91f8868beb47a98c3bf51fdb432acc36ddadc691cfd96b9df78bd922ebf859"},
-    "3.13": {"url": "https://files.pythonhosted.org/packages/f2/62/9ee0e770e5789316f5f7acedd2f29b010862df5471d7acae12ec9ca0052b/xbbg-1.1.0-cp313-cp313-manylinux_2_34_x86_64.whl", "sha256": "102efe2c3156fa4ed11411ffcd2cbc84477fbdb710299682d3eec0e2e368e448"},
+    "3.10": {"url": "https://files.pythonhosted.org/packages/71/39/ed4baf4cf3ad55ef86c413b41c211a7ac966c2b7663c392d0325dd4f2567/xbbg-1.1.1-cp310-cp310-manylinux_2_34_x86_64.whl", "sha256": "7801330db53f2f2664fe46caafb82f91ba9fd4812587ae629a04d1c769d96b33"},
+    "3.11": {"url": "https://files.pythonhosted.org/packages/d4/e1/cba5d94aef55b0a6b5f986024fde8c9ee3361486a36cffccaafcfd4a9c0b/xbbg-1.1.1-cp311-cp311-manylinux_2_34_x86_64.whl", "sha256": "5c90e8b8cc27236ce994e97d79574f79ff52b8f781fbee586ee595d6c4c304e8"},
+    "3.12": {"url": "https://files.pythonhosted.org/packages/3f/6d/eaf92cb0758290928f4d3f1282fefdc942ab0fb6ab7c9f2264b4c6927992/xbbg-1.1.1-cp312-cp312-manylinux_2_34_x86_64.whl", "sha256": "338e03810b956391f376e76c57ac3b023834ca34abcb7f53e9f96b04f84b2d49"},
+    "3.13": {"url": "https://files.pythonhosted.org/packages/b9/56/a7fc496f7c6734aa48584966f1e6dd5a3eaa307eeec77d7bab7f6e03997d/xbbg-1.1.1-cp313-cp313-manylinux_2_34_x86_64.whl", "sha256": "903cf7a3061d57b04de8bb16aea4b76f1b48a8a83b6e6558ac42b2f1bcd27899"},
   },
   "osx-arm64": {
-    "3.10": {"url": "https://files.pythonhosted.org/packages/d0/4c/1548cfde0359b864877d23e88f6a2b0afdf171eb1838e2ccf7d86d46e3b1/xbbg-1.1.0-cp310-cp310-macosx_11_0_universal2.whl", "sha256": "29d739342e9df06f499c0fd676501b07a5202d54cb8c8eaa0f0f1c9d1421f8b3"},
-    "3.11": {"url": "https://files.pythonhosted.org/packages/d2/ea/9a8f5a97359d26fc75742a3fce958d8ce9e05d278944b3acc8d7a705e6ff/xbbg-1.1.0-cp311-cp311-macosx_11_0_universal2.whl", "sha256": "6baaa4f3bf86c360b0952b5154c7db113ba1398b25477f20061b56bb706637a4"},
-    "3.12": {"url": "https://files.pythonhosted.org/packages/63/08/8d4d9d736627dd3ff9b14a1b989f908b0bb8057325af7501e177982527ec/xbbg-1.1.0-cp312-cp312-macosx_11_0_universal2.whl", "sha256": "9416a58164e6a97117c0b18d3856eec0a65f3284458cd825f2c17980c9679545"},
-    "3.13": {"url": "https://files.pythonhosted.org/packages/1e/33/134ba654acf41efdcaeb3486e4432e33d6e8602e04427c4e22bb462fb3ef/xbbg-1.1.0-cp313-cp313-macosx_11_0_universal2.whl", "sha256": "88e28d2922e068725223939a3f8ecaa7a25bd265e9c204eb83d03c91e2281eb3"},
+    "3.10": {"url": "https://files.pythonhosted.org/packages/0c/9b/528a1169e4789012f819d833674e7156f5e427537bbeea6d53d3ff9b3cca/xbbg-1.1.1-cp310-cp310-macosx_11_0_universal2.whl", "sha256": "b5b15a34a0c32356d0156c210949859f4862ee42d22d48734bba5db818d93835"},
+    "3.11": {"url": "https://files.pythonhosted.org/packages/01/94/6293919fdb231908d2c1514e939b32c6937170329b6f609d06cbdec92bdd/xbbg-1.1.1-cp311-cp311-macosx_11_0_universal2.whl", "sha256": "bde188a042fa5df14e8f36c9947997482e8cddf58e2020995a91a603865a0b89"},
+    "3.12": {"url": "https://files.pythonhosted.org/packages/6d/b5/b37a8460c0f85cc4500880a184d228388807c8cd65e10a07eb5dbc65f245/xbbg-1.1.1-cp312-cp312-macosx_11_0_universal2.whl", "sha256": "3598ba66b1e8f5d1bc8f6c66f3febd462c9a2bc15cb04cde7a372333841a64ac"},
+    "3.13": {"url": "https://files.pythonhosted.org/packages/d3/8e/ffa358f6e166675a5709d25bad01e1fde1afcac5085feaafa03e2c254553/xbbg-1.1.1-cp313-cp313-macosx_11_0_universal2.whl", "sha256": "181b21877e591c5ee2a0298faa55cbb6a14d6ac68a0bfff911a3cc8aaf5fdf69"},
   },
   "win-64": {
-    "3.10": {"url": "https://files.pythonhosted.org/packages/56/f9/d5e6ce4574b43f1846ef2b6b7de96eb4a33343016a29962766f1d620920d/xbbg-1.1.0-cp310-cp310-win_amd64.whl", "sha256": "2f87a4b9e922ac1384e8e77cd4387cdce4d507e8786243af2f902a277011b460"},
-    "3.11": {"url": "https://files.pythonhosted.org/packages/3a/90/e1d7b0d1dcb34b2f0bb5280c3e8d7e795442a2fbb7ba3a35a0bab29d6023/xbbg-1.1.0-cp311-cp311-win_amd64.whl", "sha256": "ed3763df768eaa30395eef71c0a5c498a7c502b40dc2170bd2100a60fff4b155"},
-    "3.12": {"url": "https://files.pythonhosted.org/packages/0a/39/d9d69a6d7c20ccc9c1cbfd372a99965d061662e5168ca76147bba1ca400e/xbbg-1.1.0-cp312-cp312-win_amd64.whl", "sha256": "9080e0f892680eaf9de054b001436733c238031b81373908662ee4b91a133441"},
-    "3.13": {"url": "https://files.pythonhosted.org/packages/bc/90/443db9263bb454af5033718332e61010d131eb837afb90d802aecaedec6d/xbbg-1.1.0-cp313-cp313-win_amd64.whl", "sha256": "4d99b10f1c1d2fa3a76e5b975bcf57c6d0114c72ae26a98698290fdf3bb658bc"},
+    "3.10": {"url": "https://files.pythonhosted.org/packages/78/48/10186fcff7c2ab3ecbc837b99f0f4149a9b4915f39b66ccf6d1dbd3e4d0d/xbbg-1.1.1-cp310-cp310-win_amd64.whl", "sha256": "31ac54ac39a74af4abcd3032bb2f564a5c0475e596128ccc0084214bfffbd886"},
+    "3.11": {"url": "https://files.pythonhosted.org/packages/0c/7a/16a776fc098a2fd5530f8a23d915134a52c550d4e6eaefff92195fe4dca7/xbbg-1.1.1-cp311-cp311-win_amd64.whl", "sha256": "f7d88a3253192a3bfdb03619cc13fe7b1bd27e78725f9bb745a12aa75de59e57"},
+    "3.12": {"url": "https://files.pythonhosted.org/packages/6e/46/3aae5ed077d01d2e6c55e0f37b59fe81bd77500b7ed7c4a3cc796658fd29/xbbg-1.1.1-cp312-cp312-win_amd64.whl", "sha256": "361f46a4bf257fd35cb167f95b4dbbd197dd0b917d4a96e898113df4108620ec"},
+    "3.13": {"url": "https://files.pythonhosted.org/packages/71/f3/5052ad4a3b5c9385dd685dccbe1a7d1363385ba55b2090a224fb36c3b2f6/xbbg-1.1.1-cp313-cp313-win_amd64.whl", "sha256": "0d4391c4cb9440f2a2c4bed75e4542dc82e611cef2e673d3e9dd769f8f5f0243"},
   },
 } %}
 {% set wheel = wheel_artifacts[target_platform][python_mm] %}
@@ -32,8 +32,8 @@ package:
 
 source:
   # Keep the sdist for metadata/license capture, and package the matching upstream wheel locally.
-  - url: https://files.pythonhosted.org/packages/ce/31/273744fbbe482a1031e379afaf0db23158d88d3eea1adc3224e146cda59d/xbbg-1.1.0.tar.gz
-    sha256: 1238a266447ca7def3923d087246a3c55f23952b88f10c98189ace54124ac45d
+  - url: https://files.pythonhosted.org/packages/87/b8/02766bc6124b2b0a496d690213577c0494cb4aeaad3aeb6273e889f26cdd/xbbg-1.1.1.tar.gz
+    sha256: 95154e0bc3eda63e87e3b805919ba2da7ab2556a926b8df3531fd689261218d1
     folder: sdist
   - url: {{ wheel["url"] }}
     sha256: {{ wheel["sha256"] }}


### PR DESCRIPTION
## Summary
- Bumps recipe to **xbbg 1.1.1** (stable, released on PyPI today).
- Refreshes all 12 wheel URLs + sha256s (linux-64 / osx-arm64 / win-64 × py3.10–3.13) and the sdist source.
- Rerender was a no-op — current `.ci_support/*` matches conda-smithy 3.60.0 / conda-forge-pinning 2026.04.18.15.28.11.

## Verification
- Artifact digests pulled directly from `https://pypi.org/pypi/xbbg/1.1.1/json`.
- Build matrix, pins, and `recipe/conda_build_config.yaml` absence keep publishing on the default `conda-forge` channel (the beta is on `label/xbbg_dev` via #35).

## Test plan
- [ ] CI green on linux-64 / osx-arm64 / win-64 × py3.10–3.13
- [ ] `import xbbg` passes in the `test:` stage
- [ ] Artifact published to default `conda-forge` channel