### PR TITLE
Update xbbg to 1.2.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "xbbg" %}
-{% set version = "1.2.1" %}
+{% set version = "1.2.4" %}
 {% set supported_python = ["3.10", "3.11", "3.12", "3.13", "3.14"] %}
 {% set python_mm = PY_VER if PY_VER in supported_python else "3.10" %}
 {% set abi_tag = "cp" ~ (python_mm | replace(".", "")) %}
@@ -7,25 +7,25 @@
 {% set wheel_filename = name ~ "-" ~ version ~ "-" ~ abi_tag ~ "-" ~ abi_tag ~ "-" ~ platform_tags[target_platform] ~ ".whl" %}
 {% set wheel_artifacts = {
   "linux-64": {
-    "3.10": {"url": "https://files.pythonhosted.org/packages/c9/c3/421b1006ee2deb335e4218f350eb8b554494da7c29fa3141022eaf7b16e5/xbbg-1.2.1-cp310-cp310-manylinux_2_34_x86_64.whl", "sha256": "959e796686a612345686a391627f43614d7fd19a47b71afdb1b7f789ef2c0f2d"},
-    "3.11": {"url": "https://files.pythonhosted.org/packages/89/14/827e597cb9b1a3db8578f05b52957338ecf1bfc635adcb9df4cf8533d788/xbbg-1.2.1-cp311-cp311-manylinux_2_34_x86_64.whl", "sha256": "a44c5a3e1724e1c648d03c2fc78e68810dad52304ca15e9018d5313860789fed"},
-    "3.12": {"url": "https://files.pythonhosted.org/packages/23/a4/6b55f62360b912d05f1ae2ae1bca8e71b10602cf13ca3db5230becddf7aa/xbbg-1.2.1-cp312-cp312-manylinux_2_34_x86_64.whl", "sha256": "dd190c1dae6848830ef11e7cdcb269cdd1fc33f9f15ae30045f45bad600ce7f1"},
-    "3.13": {"url": "https://files.pythonhosted.org/packages/33/6c/34b99461b9f7310b6828b7666cf9d3826f03612f4a89a3f582a2b38ca315/xbbg-1.2.1-cp313-cp313-manylinux_2_34_x86_64.whl", "sha256": "ed4a9e01e9d707754ce5db3b13eb62b14d9e7b8b398866691af67488fab88ac2"},
-    "3.14": {"url": "https://files.pythonhosted.org/packages/6a/a5/c4badbb9a5eebd35b9a2c96f0aba920813261c01bc70aa97c627e7538600/xbbg-1.2.1-cp314-cp314-manylinux_2_34_x86_64.whl", "sha256": "931ec5590a28e7dabdeda16712d726032ea67f3e79c0756efb3159ebd8142513"},
+    "3.10": {"url": "https://files.pythonhosted.org/packages/e6/c8/6061e330e0df7b0ad5b87ab3ec0ac15b74e157fbd9ea1de056c960596186/xbbg-1.2.4-cp310-cp310-manylinux_2_34_x86_64.whl", "sha256": "003a800a80484c84c868f24febef23b2789284483f4fc99d0314a4a0762fd234"},
+    "3.11": {"url": "https://files.pythonhosted.org/packages/8a/26/67250f82aa9dfdc8e56b8917383ccb0a7660f464c4c8bb1a84cb0ffac1c9/xbbg-1.2.4-cp311-cp311-manylinux_2_34_x86_64.whl", "sha256": "d0f38e5c94b5c44653eafd3846a5c210418cc7dc25b5c0ea9dae96d4f184919c"},
+    "3.12": {"url": "https://files.pythonhosted.org/packages/90/16/613ac30cf770307b014d39e08be2d20f9ebd8824e772767424cb1348fcb6/xbbg-1.2.4-cp312-cp312-manylinux_2_34_x86_64.whl", "sha256": "7ceadd8bf8c8833b9adfd8edd580973535eb14540035425fc71410640af0d5f6"},
+    "3.13": {"url": "https://files.pythonhosted.org/packages/48/57/c343ccf832d4b705c2b383ece2ad2a826fbbc820c53f8f6dfaf89dd05200/xbbg-1.2.4-cp313-cp313-manylinux_2_34_x86_64.whl", "sha256": "436499181f0bdd94231c53a71c4b4368b526f06a02609cfef9def3d6d83c311e"},
+    "3.14": {"url": "https://files.pythonhosted.org/packages/71/41/db689295da3cf8b667139ff7a3e35748cb0478548207c46afbc4c2cb9477/xbbg-1.2.4-cp314-cp314-manylinux_2_34_x86_64.whl", "sha256": "b96041a28b1b51163b6d67962189ddd124111ad594ab9abab4b95f3010d7183b"},
   },
   "osx-arm64": {
-    "3.10": {"url": "https://files.pythonhosted.org/packages/d1/2a/2a3ebcd6492255c9b79e2b278919ab234c5355ad10beb58b8462ac6ccb35/xbbg-1.2.1-cp310-cp310-macosx_11_0_universal2.whl", "sha256": "edf460203e614536272e6e1824b3e2a292e65ea75918a79c37907afe276778aa"},
-    "3.11": {"url": "https://files.pythonhosted.org/packages/20/81/59c8c891ceb3912ecf9a0071b9b2cfbca32121a7f6f45e7794f22a2db2d2/xbbg-1.2.1-cp311-cp311-macosx_11_0_universal2.whl", "sha256": "a6a1d9fe3ab812fded9ff2d27e14fd2d7c8c0053227b5332f0f9d8f64d22368d"},
-    "3.12": {"url": "https://files.pythonhosted.org/packages/f2/2c/5bbbb2c45ad5d59871fa35de44c13ec9edce87d6beb77a405dd863fb7b8f/xbbg-1.2.1-cp312-cp312-macosx_11_0_universal2.whl", "sha256": "0fd5f08de9c941996c4d7a4693700ea563b713f9973df39d30016e37e8fc8650"},
-    "3.13": {"url": "https://files.pythonhosted.org/packages/b2/39/2cdc62099dd0aba953530c32c7aecc34874bc16ce5fc896dcebe8ec0f6ae/xbbg-1.2.1-cp313-cp313-macosx_11_0_universal2.whl", "sha256": "9c232139d19e0c0b608069e12ffe9b318de33a2f724a6393ec9b6bb7df51fce0"},
-    "3.14": {"url": "https://files.pythonhosted.org/packages/77/55/376f24057df2610d43c14e454f83adafa9fff82a3602f89ee5a77861401a/xbbg-1.2.1-cp314-cp314-macosx_11_0_universal2.whl", "sha256": "d6cd09c96194b8ae783490fd1870e711ab338cd1d5d1fd67e8b8eba1f205f20a"},
+    "3.10": {"url": "https://files.pythonhosted.org/packages/a0/21/0c087fbd4c73752e501ab39a0066e7413fc260eab975c9185f79053f0141/xbbg-1.2.4-cp310-cp310-macosx_11_0_universal2.whl", "sha256": "3669d3a9d09874f774cec62a4f576d81ea7741fecddc33fdfc322836b1c5b44e"},
+    "3.11": {"url": "https://files.pythonhosted.org/packages/0b/d7/bae2b1e47fa403f26a071ace566b8ed5c460638145c5e77cc2cd9355d06e/xbbg-1.2.4-cp311-cp311-macosx_11_0_universal2.whl", "sha256": "e670b6c8d05468a1d4a9c0e6c7401499b03f29b2b3c2442898e61468d4ee1d4f"},
+    "3.12": {"url": "https://files.pythonhosted.org/packages/eb/db/88ef0270d12630653e661bb383d113c73b6c0d9e2f5d9be3f2873bcf0b0e/xbbg-1.2.4-cp312-cp312-macosx_11_0_universal2.whl", "sha256": "44d5514db7bc8d2da14fb51b9a297429f8afd4c66892414ca59c79b344d97932"},
+    "3.13": {"url": "https://files.pythonhosted.org/packages/a0/62/ab302aa8510fb2dbee4fffc360e5fb1624ca138447f658dc263cc6109917/xbbg-1.2.4-cp313-cp313-macosx_11_0_universal2.whl", "sha256": "a499df76ba6164753fc1432db0f95232f375a7073415817b1e185f3eea33c55b"},
+    "3.14": {"url": "https://files.pythonhosted.org/packages/25/17/f0ffdca0e390f3cfc95637675b627ef4bf28a5cfc0c1a566c7cc5497e384/xbbg-1.2.4-cp314-cp314-macosx_11_0_universal2.whl", "sha256": "4951ab50a5782baad3b14ff5936c86e5d1ae415519c360d4033356ce1490c368"},
   },
   "win-64": {
-    "3.10": {"url": "https://files.pythonhosted.org/packages/a7/d9/76096eb127d0aac0e7d01b920a6e662a57a0d326902e01b93426d4081f9a/xbbg-1.2.1-cp310-cp310-win_amd64.whl", "sha256": "e5dd5f0d13ff350194db01ee732c0fd1a6dca0c36c963794bd39f6fe79204b11"},
-    "3.11": {"url": "https://files.pythonhosted.org/packages/27/e1/c5f1cea92641856a54c61512f7d82dd7888d8d2f42a50581fd9458a9d04d/xbbg-1.2.1-cp311-cp311-win_amd64.whl", "sha256": "24183d338cb5a0ea43c5c662be6b97193ee302537dcdb977c604770071239140"},
-    "3.12": {"url": "https://files.pythonhosted.org/packages/a1/2b/c9e059c9a7d3152af1a43f274679d37ae3b55e2d8f2682ca51feab39aa16/xbbg-1.2.1-cp312-cp312-win_amd64.whl", "sha256": "3db503f37312077fa9e0bb5e0b7732b755f71114fd3c0f1118a223f964bd1584"},
-    "3.13": {"url": "https://files.pythonhosted.org/packages/4e/ce/68d9613460bde2f45672444c3b8c2ca25efb4b96bd944e51b154683e6247/xbbg-1.2.1-cp313-cp313-win_amd64.whl", "sha256": "1a37e7a3a8162a3091b6d2f34ca2ec20437270032805e2b3134b5e88b12407ae"},
-    "3.14": {"url": "https://files.pythonhosted.org/packages/32/c8/667d6fe91dd75841193a27436856d8348fd05bff0096102557bc757e1317/xbbg-1.2.1-cp314-cp314-win_amd64.whl", "sha256": "8c3c37d7440d5767cc3c3be8cccfa02c3647d4a9bb540e73ec13806fb0fca1d9"},
+    "3.10": {"url": "https://files.pythonhosted.org/packages/1d/9b/9bf10e747dff7d7b8210b516feab69ddff50fe157385a05b5b2e31e3c150/xbbg-1.2.4-cp310-cp310-win_amd64.whl", "sha256": "d04b89ab2b627d06fbbad68987f04badd9351a678bc65bf8524816e280731ebc"},
+    "3.11": {"url": "https://files.pythonhosted.org/packages/3e/18/61dec4dd7681ee0447738300564a43e7e84362f4e02895927b1508e716c5/xbbg-1.2.4-cp311-cp311-win_amd64.whl", "sha256": "f2a8754fe8469b1bb6c5262a93bd6f20c86e0c05708c8fa8fa3a60a0686c6fe3"},
+    "3.12": {"url": "https://files.pythonhosted.org/packages/a0/46/144d3d0200a2c971153d5e5f51eea8d03535fc4fdb4572ba420091f429c3/xbbg-1.2.4-cp312-cp312-win_amd64.whl", "sha256": "01fb8651963df18b5b3768b036d3c47bbff3c54520ad4a8e00e4bd983e117f9c"},
+    "3.13": {"url": "https://files.pythonhosted.org/packages/01/df/25d2453045da2652998004d1d65b720791b925bbc7c8da65ec7cc074e703/xbbg-1.2.4-cp313-cp313-win_amd64.whl", "sha256": "f0054759a23ec90d7208c3156d10d4d758670584e46c9dee0fbfd2062e6d7801"},
+    "3.14": {"url": "https://files.pythonhosted.org/packages/ae/18/e69f938b299368c6be2b67708ebcc427b4e4841a55ce98168c66a36a49fe/xbbg-1.2.4-cp314-cp314-win_amd64.whl", "sha256": "87418d2da6ca5ff42a68f3eff483864f1f2b48881bb782ceca443d4480ef925a"},
   },
 } %}
 {% set wheel = wheel_artifacts[target_platform][python_mm] %}
@@ -36,15 +36,15 @@ package:
 
 source:
   # Keep the sdist for metadata/license capture, and package the matching upstream wheel locally.
-  - url: https://files.pythonhosted.org/packages/68/08/c7d2ce64f04b3acc100d09379aa004de9e39b94e0f191040d8b91bec618a/xbbg-1.2.1.tar.gz
-    sha256: c1ccae56934ff011925b5b4126065156d91e79c252038a158a79e6706b7b1962
+  - url: https://files.pythonhosted.org/packages/05/83/5112db81acd8b5b9e3a93fcd08524d7388a5be015fdc993b467a2cccea09/xbbg-1.2.4.tar.gz
+    sha256: 0a8f7c7768b119dd31b77b31e8b4d1adc7cd4a69b8e60c518d8b93807980f728
     folder: sdist
   - url: {{ wheel["url"] }}
     sha256: {{ wheel["sha256"] }}
     fn: {{ wheel_filename }}
 
 build:
-  number: 1
+  number: 0
   skip: true  # [py<310 or py>=315 or (osx and x86_64)]
   script:
     - export PIP_NO_INDEX=false                                                                                                # [unix]


### PR DESCRIPTION
Updates xbbg from 1.2.1 to 1.2.4 and resets the build number to 0.\n\nValidation performed locally:\n- conda-smithy rerender: no generated changes needed\n- conda-smithy recipe-lint recipe\n- verified all 15 wheels plus sdist URLs and sha256 values against PyPI xbbg 1.2.4 metadata\n- conda-build recipe -m .ci_support/win_64_python3.12.____cpython.yaml -c conda-forge --suppress-variables --no-anaconda-upload