### PR TITLE
Improve xbbg package metadata

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,7 @@ source:
     fn: {{ wheel_filename }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<310 or py>=315 or (osx and x86_64)]
   script:
     - export PIP_NO_INDEX=false                                                                                                # [unix]
@@ -73,6 +73,13 @@ about:
   license_family: Apache
   license_file: sdist/LICENSE
   summary: Independent client for Bloomberg-connected data workflows
+  description: |
+    xbbg is an independent Bloomberg client for authorized Bloomberg environments.
+    It provides Python APIs backed by a Rust engine for request/response workflows,
+    subscriptions, async execution, typed errors, diagnostics, and Narwhals-native
+    data outputs. Current v1 conda-forge builds are platform-specific packages for
+    linux-64, osx-arm64, and win-64 on Python 3.10 through 3.14; older noarch
+    entries on anaconda.org are historical v0.x builds.
   doc_url: https://xbbg.org/
   dev_url: https://github.com/alpha-xone/xbbg
 


### PR DESCRIPTION
Adds an about.description so the anaconda.org package page is not blank and explicitly explains that current v1 builds are platform-specific while noarch entries are historical v0.x artifacts.\n\nThis is a metadata-only rebuild of xbbg 1.2.4, so the build number is bumped from 0 to 1.\n\nValidation performed locally:\n- conda-smithy recipe-lint recipe\n- conda render recipe -m .ci_support/win_64_python3.12.____cpython.yaml -c conda-forge\n- conda-build recipe -m .ci_support/win_64_python3.12.____cpython.yaml -c conda-forge --suppress-variables --no-anaconda-upload