### PR TITLE
Improve xbbg search metadata

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,7 @@ source:
     fn: {{ wheel_filename }}
 
 build:
-  number: 1
+  number: 2
   skip: true  # [py<310 or py>=315 or (osx and x86_64)]
   script:
     - export PIP_NO_INDEX=false                                                                                                # [unix]
@@ -72,14 +72,16 @@ about:
   license: Apache-2.0
   license_family: Apache
   license_file: sdist/LICENSE
-  summary: Independent client for Bloomberg-connected data workflows
+  summary: Independent Bloomberg BLPAPI client for Python data workflows
   description: |
-    xbbg is an independent Bloomberg client for authorized Bloomberg environments.
-    It provides Python APIs backed by a Rust engine for request/response workflows,
-    subscriptions, async execution, typed errors, diagnostics, and Narwhals-native
-    data outputs. Current v1 conda-forge builds are platform-specific packages for
-    linux-64, osx-arm64, and win-64 on Python 3.10 through 3.14; older noarch
-    entries on anaconda.org are historical v0.x builds.
+    xbbg is an independent Bloomberg BLPAPI client for authorized Bloomberg
+    environments. It provides Python APIs backed by a Rust engine for BDP, BDS,
+    BDH, BQL, BEQS, BSRCH, intraday bars, ticks, subscriptions, async execution,
+    typed errors, diagnostics, and Arrow/Narwhals-native data outputs. Supported
+    connection modes include Bloomberg Desktop API/DAPI, SAPI/B-PIPE, and ZFP.
+    Current v1 conda-forge builds are platform-specific packages for linux-64,
+    osx-arm64, and win-64 on Python 3.10 through 3.14; older noarch entries on
+    anaconda.org are historical v0.x builds.
   doc_url: https://xbbg.org/
   dev_url: https://github.com/alpha-xone/xbbg
 


### PR DESCRIPTION
Improves the Anaconda.org search card and package description with common search terms: Bloomberg BLPAPI, Python, BDP, BDS, BDH, BQL, BEQS, BSRCH, DAPI, SAPI/B-PIPE, ZFP, Arrow, and Narwhals.\n\nThis is a metadata-only rebuild of xbbg 1.2.4, so the build number is bumped from 1 to 2.\n\nValidation performed locally:\n- conda-smithy recipe-lint recipe\n- conda render recipe -m .ci_support/win_64_python3.12.____cpython.yaml -c conda-forge\n- conda-build recipe -m .ci_support/win_64_python3.12.____cpython.yaml -c conda-forge --suppress-variables --no-anaconda-upload