### PR TITLE
Fix xbbg feedstock version automation

### DIFF
--- a/.ci_support/linux_64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_python3.10.____cpython.yaml
@@ -1,3 +1,11 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -10,5 +18,7 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.10.* *_cpython
+rust_compiler:
+- rust
 target_platform:
 - linux-64

--- a/.ci_support/linux_64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_python3.11.____cpython.yaml
@@ -1,3 +1,11 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -10,5 +18,7 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.11.* *_cpython
+rust_compiler:
+- rust
 target_platform:
 - linux-64

--- a/.ci_support/linux_64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_python3.12.____cpython.yaml
@@ -1,3 +1,11 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -10,5 +18,7 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.12.* *_cpython
+rust_compiler:
+- rust
 target_platform:
 - linux-64

--- a/.ci_support/linux_64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_python3.13.____cp313.yaml
@@ -1,3 +1,11 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -10,5 +18,7 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.13.* *_cp313
+rust_compiler:
+- rust
 target_platform:
 - linux-64

--- a/.ci_support/linux_64_python3.14.____cp314.yaml
+++ b/.ci_support/linux_64_python3.14.____cp314.yaml
@@ -1,3 +1,11 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -10,5 +18,7 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.14.* *_cp314
+rust_compiler:
+- rust
 target_platform:
 - linux-64

--- a/.ci_support/osx_arm64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpython.yaml
@@ -2,6 +2,14 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -14,5 +22,7 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.10.* *_cpython
+rust_compiler:
+- rust
 target_platform:
 - osx-arm64

--- a/.ci_support/osx_arm64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpython.yaml
@@ -2,6 +2,14 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -14,5 +22,7 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.11.* *_cpython
+rust_compiler:
+- rust
 target_platform:
 - osx-arm64

--- a/.ci_support/osx_arm64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.12.____cpython.yaml
@@ -2,6 +2,14 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -14,5 +22,7 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.12.* *_cpython
+rust_compiler:
+- rust
 target_platform:
 - osx-arm64

--- a/.ci_support/osx_arm64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_python3.13.____cp313.yaml
@@ -2,6 +2,14 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -14,5 +22,7 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.13.* *_cp313
+rust_compiler:
+- rust
 target_platform:
 - osx-arm64

--- a/.ci_support/osx_arm64_python3.14.____cp314.yaml
+++ b/.ci_support/osx_arm64_python3.14.____cp314.yaml
@@ -2,6 +2,14 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -14,5 +22,7 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.14.* *_cp314
+rust_compiler:
+- rust
 target_platform:
 - osx-arm64

--- a/.ci_support/win_64_python3.10.____cpython.yaml
+++ b/.ci_support/win_64_python3.10.____cpython.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- vs2022
+c_stdlib:
+- vs
 channel_sources:
 - conda-forge
 channel_targets:
@@ -8,5 +12,7 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.10.* *_cpython
+rust_compiler:
+- rust
 target_platform:
 - win-64

--- a/.ci_support/win_64_python3.11.____cpython.yaml
+++ b/.ci_support/win_64_python3.11.____cpython.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- vs2022
+c_stdlib:
+- vs
 channel_sources:
 - conda-forge
 channel_targets:
@@ -8,5 +12,7 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.11.* *_cpython
+rust_compiler:
+- rust
 target_platform:
 - win-64

--- a/.ci_support/win_64_python3.12.____cpython.yaml
+++ b/.ci_support/win_64_python3.12.____cpython.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- vs2022
+c_stdlib:
+- vs
 channel_sources:
 - conda-forge
 channel_targets:
@@ -8,5 +12,7 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.12.* *_cpython
+rust_compiler:
+- rust
 target_platform:
 - win-64

--- a/.ci_support/win_64_python3.13.____cp313.yaml
+++ b/.ci_support/win_64_python3.13.____cp313.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- vs2022
+c_stdlib:
+- vs
 channel_sources:
 - conda-forge
 channel_targets:
@@ -8,5 +12,7 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.13.* *_cp313
+rust_compiler:
+- rust
 target_platform:
 - win-64

--- a/.ci_support/win_64_python3.14.____cp314.yaml
+++ b/.ci_support/win_64_python3.14.____cp314.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- vs2022
+c_stdlib:
+- vs
 channel_sources:
 - conda-forge
 channel_targets:
@@ -8,5 +12,7 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.14.* *_cp314
+rust_compiler:
+- rust
 target_platform:
 - win-64

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @m3ridian-zero @kj55-dev @makoponi
+* @m3ridian-zero @makoponi

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -23,138 +23,242 @@ jobs:
       matrix:
         include:
           - CONFIG: linux_64_python3.10.____cpython
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
+            free_disk_space: skip
             os: ubuntu
+            pagefile_size: 0
+            resize_partitions: False
             runs_on: ['ubuntu-latest']
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
           - CONFIG: linux_64_python3.11.____cpython
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
+            free_disk_space: skip
             os: ubuntu
+            pagefile_size: 0
+            resize_partitions: False
             runs_on: ['ubuntu-latest']
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
           - CONFIG: linux_64_python3.12.____cpython
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
+            free_disk_space: skip
             os: ubuntu
+            pagefile_size: 0
+            resize_partitions: False
             runs_on: ['ubuntu-latest']
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
           - CONFIG: linux_64_python3.13.____cp313
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
+            free_disk_space: skip
             os: ubuntu
+            pagefile_size: 0
+            resize_partitions: False
             runs_on: ['ubuntu-latest']
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
           - CONFIG: linux_64_python3.14.____cp314
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
+            free_disk_space: skip
             os: ubuntu
+            pagefile_size: 0
+            resize_partitions: False
             runs_on: ['ubuntu-latest']
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
           - CONFIG: osx_arm64_python3.10.____cpython
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
+            build_workspace_dir: ~/miniforge3/conda-bld
+            docker_run_args: 
+            free_disk_space: skip
             os: macos
-            runs_on: ['macos-latest']
+            pagefile_size: 0
+            resize_partitions: False
+            runs_on: ['macos-15']
+            tools_install_dir: ~/miniforge3
           - CONFIG: osx_arm64_python3.11.____cpython
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
+            build_workspace_dir: ~/miniforge3/conda-bld
+            docker_run_args: 
+            free_disk_space: skip
             os: macos
-            runs_on: ['macos-latest']
+            pagefile_size: 0
+            resize_partitions: False
+            runs_on: ['macos-15']
+            tools_install_dir: ~/miniforge3
           - CONFIG: osx_arm64_python3.12.____cpython
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
+            build_workspace_dir: ~/miniforge3/conda-bld
+            docker_run_args: 
+            free_disk_space: skip
             os: macos
-            runs_on: ['macos-latest']
+            pagefile_size: 0
+            resize_partitions: False
+            runs_on: ['macos-15']
+            tools_install_dir: ~/miniforge3
           - CONFIG: osx_arm64_python3.13.____cp313
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
+            build_workspace_dir: ~/miniforge3/conda-bld
+            docker_run_args: 
+            free_disk_space: skip
             os: macos
-            runs_on: ['macos-latest']
+            pagefile_size: 0
+            resize_partitions: False
+            runs_on: ['macos-15']
+            tools_install_dir: ~/miniforge3
           - CONFIG: osx_arm64_python3.14.____cp314
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
+            build_workspace_dir: ~/miniforge3/conda-bld
+            docker_run_args: 
+            free_disk_space: skip
             os: macos
-            runs_on: ['macos-latest']
+            pagefile_size: 0
+            resize_partitions: False
+            runs_on: ['macos-15']
+            tools_install_dir: ~/miniforge3
           - CONFIG: win_64_python3.10.____cpython
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
+            build_workspace_dir: D:\\bld\\
+            docker_run_args: 
+            free_disk_space: skip
             os: windows
-            runs_on: ['windows-latest']
+            pagefile_size: 0
+            resize_partitions: False
+            runs_on: ['windows-2022']
+            tools_install_dir: D:\Miniforge
           - CONFIG: win_64_python3.11.____cpython
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
+            build_workspace_dir: D:\\bld\\
+            docker_run_args: 
+            free_disk_space: skip
             os: windows
-            runs_on: ['windows-latest']
+            pagefile_size: 0
+            resize_partitions: False
+            runs_on: ['windows-2022']
+            tools_install_dir: D:\Miniforge
           - CONFIG: win_64_python3.12.____cpython
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
+            build_workspace_dir: D:\\bld\\
+            docker_run_args: 
+            free_disk_space: skip
             os: windows
-            runs_on: ['windows-latest']
+            pagefile_size: 0
+            resize_partitions: False
+            runs_on: ['windows-2022']
+            tools_install_dir: D:\Miniforge
           - CONFIG: win_64_python3.13.____cp313
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
+            build_workspace_dir: D:\\bld\\
+            docker_run_args: 
+            free_disk_space: skip
             os: windows
-            runs_on: ['windows-latest']
+            pagefile_size: 0
+            resize_partitions: False
+            runs_on: ['windows-2022']
+            tools_install_dir: D:\Miniforge
           - CONFIG: win_64_python3.14.____cp314
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
+            build_workspace_dir: D:\\bld\\
+            docker_run_args: 
+            free_disk_space: skip
             os: windows
-            runs_on: ['windows-latest']
+            pagefile_size: 0
+            resize_partitions: False
+            runs_on: ['windows-2022']
+            tools_install_dir: D:\Miniforge
     steps:
 
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Configure binfmt_misc
+      if: matrix.os == 'ubuntu'
+      shell: bash
+      run: |
+        if [[ "$(uname -m)" == "x86_64" ]]; then
+          docker run --rm --privileged multiarch/qemu-user-static:register --reset --credential yes
+        fi
 
     - name: Build on Linux
       id: build-linux
       if: matrix.os == 'ubuntu'
       env:
-        CONFIG: ${{ matrix.CONFIG }}
-        UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
-        DOCKER_IMAGE: ${{ matrix.DOCKER_IMAGE }}
         CI: github_actions
-        CONDA_FORGE_DOCKER_RUN_ARGS: "${{ matrix.CONDA_FORGE_DOCKER_RUN_ARGS }}"
+        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
+        CONDA_FORGE_DOCKER_RUN_ARGS: ${{ matrix.docker_run_args }}
+        CONFIG: ${{ matrix.CONFIG }}
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        DOCKER_IMAGE: ${{ matrix.DOCKER_IMAGE }}
+        UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
+        RATTLER_BUILD_COLOR: always
+        RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
         BINSTAR_TOKEN: ${{ secrets.BINSTAR_TOKEN }}
         FEEDSTOCK_TOKEN: ${{ secrets.FEEDSTOCK_TOKEN }}
         STAGING_BINSTAR_TOKEN: ${{ secrets.STAGING_BINSTAR_TOKEN }}
       shell: bash
       run: |
-        if [[ "$(uname -m)" == "x86_64" ]]; then
-          echo "::group::Configure binfmt_misc"
-          docker run --rm --privileged multiarch/qemu-user-static:register --reset --credential yes
-        fi
+        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
+        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
+        export GIT_BRANCH="$(basename $GITHUB_REF)"
+        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
         export flow_run_id="github_$GITHUB_RUN_ID"
         export remote_url="https://github.com/$GITHUB_REPOSITORY"
         export sha="$GITHUB_SHA"
-        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
-        export GIT_BRANCH="$(basename $GITHUB_REF)"
         if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
           export IS_PR_BUILD="True"
         else
           export IS_PR_BUILD="False"
         fi
-        echo "::endgroup::"
         ./.scripts/run_docker_build.sh
 
     - name: Build on macOS
       id: build-macos
       if: matrix.os == 'macos'
       env:
-        CONFIG: ${{ matrix.CONFIG }}
-        UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
         CI: github_actions
+        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
+        CONFIG: ${{ matrix.CONFIG }}
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
+        RATTLER_BUILD_COLOR: always
+        RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
         BINSTAR_TOKEN: ${{ secrets.BINSTAR_TOKEN }}
         FEEDSTOCK_TOKEN: ${{ secrets.FEEDSTOCK_TOKEN }}
         STAGING_BINSTAR_TOKEN: ${{ secrets.STAGING_BINSTAR_TOKEN }}
       shell: bash
       run: |
+        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
+        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
+        export GIT_BRANCH="$(basename $GITHUB_REF)"
+        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
         export flow_run_id="github_$GITHUB_RUN_ID"
         export remote_url="https://github.com/$GITHUB_REPOSITORY"
         export sha="$GITHUB_SHA"
-        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
-        export GIT_BRANCH="$(basename $GITHUB_REF)"
         if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
           export IS_PR_BUILD="True"
         else
@@ -172,14 +276,14 @@ jobs:
         set "sha=%GITHUB_SHA%"
         call ".scripts\run_win_build.bat"
       env:
-        # default value; make it explicit, as it needs to match with artefact
-        # generation below. Not configurable for now, can be revisited later
-        CONDA_BLD_PATH: C:\bld
-        MINIFORGE_HOME: ${{ contains(runner.arch, 'ARM') && 'C' || 'D' }}:\Miniforge
-        PYTHONUNBUFFERED: 1
-        CONFIG: ${{ matrix.CONFIG }}
         CI: github_actions
+        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
+        CONFIG: ${{ matrix.CONFIG }}
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        PYTHONUNBUFFERED: 1
         UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
+        RATTLER_BUILD_COLOR: always
+        RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
         BINSTAR_TOKEN: ${{ secrets.BINSTAR_TOKEN }}
         FEEDSTOCK_TOKEN: ${{ secrets.FEEDSTOCK_TOKEN }}
         STAGING_BINSTAR_TOKEN: ${{ secrets.STAGING_BINSTAR_TOKEN }}

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -36,7 +36,7 @@ mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-
 echo > /opt/conda/conda-meta/history
 micromamba install --root-prefix ~/.conda --prefix /opt/conda \
     --yes --override-channels --channel conda-forge --strict-channel-priority \
-    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=26.3"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 # set up the condarc
@@ -58,18 +58,33 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
 fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
-    if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
-        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
-    fi
-    conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    # differences between conda-build vs. rattler-build
+    #   - 1 step (conda debug + manually open shell) vs. 2 step (rb debug {setup, shell})
+    #   - recipe is positional vs. --recipe "${RECIPE_ROOT}"
+    #   - --output-id vs. --output-name
+    #   - --clobber-file vs. none
+    #   - none vs. --target-platform
+    conda debug \
+        "${RECIPE_ROOT}" \
+        -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         ${EXTRA_CB_OPTIONS:-} \
+        ${BUILD_OUTPUT_ID:+--output-id "${BUILD_OUTPUT_ID}"} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
 
     # Drop into an interactive shell
     /bin/bash
 else
-    conda-build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        --suppress-variables ${EXTRA_CB_OPTIONS:-} \
+    # differences between conda-build vs. rattler-build
+    #   - recipe is positional vs. --recipe "${RECIPE_ROOT}"
+    #   - --suppress-variables vs. none
+    #   - --clobber-file vs. none
+    #   - none vs. --target-platform
+    #   - --extra-meta a=b c=d vs. --extra-meta a=b --extra-meta c=d
+    conda-build \
+        "${RECIPE_ROOT}" \
+        -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+        ${EXTRA_CB_OPTIONS:-} \
+        --suppress-variables \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
     ( startgroup "Inspecting artifacts" ) 2> /dev/null

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -96,6 +96,14 @@ if [ "${DOCKER_EXECUTABLE}" = "podman" ]; then
     fi
 fi
 
+# When running on GitHub Actions, mount the step summary file into the container
+# and point GITHUB_STEP_SUMMARY at it so that rattler-build's GitHub integration
+# can write its summary. GitHub writes the file out to the job summary after the
+# step finishes.
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    DOCKER_RUN_ARGS="${DOCKER_RUN_ARGS} -v ${GITHUB_STEP_SUMMARY}:/home/conda/github_step_summary:rw${VOLUME_SUFFIX},delegated -e GITHUB_STEP_SUMMARY=/home/conda/github_step_summary"
+fi
+
 ( endgroup "Configure Docker" ) 2> /dev/null
 ( startgroup "Start Docker" ) 2> /dev/null
 
@@ -107,17 +115,20 @@ ${DOCKER_EXECUTABLE} pull "${DOCKER_IMAGE}"
 ${DOCKER_EXECUTABLE} run ${DOCKER_RUN_ARGS} \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw${VOLUME_SUFFIX},delegated \
            -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw${VOLUME_SUFFIX},delegated \
-           -e CONFIG \
-           -e HOST_USER_ID \
-           -e UPLOAD_PACKAGES \
-           -e IS_PR_BUILD \
-           -e GIT_BRANCH \
-           -e UPLOAD_ON_BRANCH \
-           -e CI \
-           -e FEEDSTOCK_NAME \
-           -e CPU_COUNT \
-           -e BUILD_WITH_CONDA_DEBUG \
            -e BUILD_OUTPUT_ID \
+           -e BUILD_WITH_CONDA_DEBUG \
+           -e CI \
+           -e CONFIG \
+           -e CPU_COUNT \
+           -e FEEDSTOCK_NAME \
+           -e GIT_BRANCH \
+           -e GITHUB_ACTIONS \
+           -e HOST_USER_ID \
+           -e IS_PR_BUILD \
+           -e RATTLER_BUILD_COLOR \
+           -e RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION \
+           -e UPLOAD_ON_BRANCH \
+           -e UPLOAD_PACKAGES \
            -e flow_run_id \
            -e remote_url \
            -e sha \

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -26,7 +26,7 @@ chmod +x "${micromamba_exe}"
 echo "Creating environment"
 "${micromamba_exe}" create --yes --root-prefix "${MAMBA_ROOT_PREFIX}" --prefix "${MINIFORGE_HOME}" \
   --channel conda-forge \
-  pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+  pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=26.3"
 echo "Moving pkgs cache from ${MAMBA_ROOT_PREFIX} to ${MINIFORGE_HOME}"
 mv "${MAMBA_ROOT_PREFIX}/pkgs" "${MINIFORGE_HOME}"
 echo "Cleaning up micromamba"
@@ -73,7 +73,7 @@ if [[ "${OSX_SDK_DIR:-}" == "" ]]; then
     /usr/bin/sudo chown "${USER}" "${OSX_SDK_DIR}"
   fi
 else
-  if tmpf=$(mktemp -p "$OSX_SDK_DIR" tmp.XXXXXXXX 2>/dev/null); then
+  if tmpf=$(mktemp "$OSX_SDK_DIR"/tmp.XXXXXXXX 2>/dev/null); then
       rm -f "$tmpf"
       echo "OSX_SDK_DIR is writeable without sudo, continuing"
   else

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -31,7 +31,7 @@ if !errorlevel! neq 0 exit /b !errorlevel!
 echo Creating environment
 call "%MICROMAMBA_EXE%" create --yes --root-prefix "%MAMBA_ROOT_PREFIX%" --prefix "%MINIFORGE_HOME%" ^
     --channel conda-forge ^
-    pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+    pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=26.3"
 if !errorlevel! neq 0 exit /b !errorlevel!
 echo Removing %MAMBA_ROOT_PREFIX%
 del /S /Q "%MAMBA_ROOT_PREFIX%" >nul

--- a/README.md
+++ b/README.md
@@ -7,17 +7,34 @@ Home: https://xbbg.org/
 
 Package license: Apache-2.0
 
-Summary: Independent client for Bloomberg-connected data workflows
+Summary: Independent Bloomberg BLPAPI client for Python data workflows
 
-Development: https://github.com/alpha-xone/xbbg
+Development: https://github.com/xbbg-org/xbbg
 
 Documentation: https://xbbg.org/
+
+xbbg is an independent Bloomberg BLPAPI client for authorized Bloomberg
+environments. It provides Python APIs backed by a Rust engine for BDP, BDS,
+BDH, BQL, BEQS, BSRCH, intraday bars, ticks, subscriptions, async execution,
+typed errors, diagnostics, and Arrow/Narwhals-native data outputs. Supported
+connection modes include Bloomberg Desktop API/DAPI, SAPI/B-PIPE, and ZFP.
+Current v1 conda-forge builds are platform-specific packages for linux-64,
+osx-arm64, and win-64 on Python 3.10 through 3.14; older noarch entries on
+anaconda.org are historical v0.x builds.
+
 
 Current build status
 ====================
 
 
-<table>
+<table><tr>
+    <td>GitHub Actions</td>
+    <td>
+      <a href="https://github.com/conda-forge/xbbg-feedstock/actions/workflows/conda-build.yml">
+        <img src="https://github.com/conda-forge/xbbg-feedstock/actions/workflows/conda-build.yml/badge.svg?event=push&branch=main">
+      </a>
+    </td>
+  </tr>
 </table>
 
 Current release info
@@ -141,6 +158,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-* [@kj55-dev](https://github.com/kj55-dev/)
+* [@m3ridian-zero](https://github.com/m3ridian-zero/)
 * [@makoponi](https://github.com/makoponi/)
 

--- a/build-locally.py
+++ b/build-locally.py
@@ -98,7 +98,10 @@ def main(args=None):
     p.add_argument(
         "--debug",
         action="store_true",
-        help="Setup debug environment using `conda debug`",
+        help=(
+            "Setup debug environment using `conda debug` "
+            "(or `rattler-build debug` for rattler-build recipes)"
+        ),
     )
     p.add_argument("--output-id", help="If running debug, specify the output to setup.")
 

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -2,7 +2,7 @@ conda_forge_output_validation: true
 bot:
   version_updates:
     sources:
-      - github
+      - pypi
 github:
   branch_name: main
   tooling_branch_name: main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,65 +1,50 @@
 {% set name = "xbbg" %}
-{% set version = "1.2.4" %}
-{% set supported_python = ["3.10", "3.11", "3.12", "3.13", "3.14"] %}
-{% set python_mm = PY_VER if PY_VER in supported_python else "3.10" %}
-{% set abi_tag = "cp" ~ (python_mm | replace(".", "")) %}
-{% set platform_tags = {"linux-64": "manylinux_2_34_x86_64", "osx-arm64": "macosx_11_0_universal2", "win-64": "win_amd64"} %}
-{% set wheel_filename = name ~ "-" ~ version ~ "-" ~ abi_tag ~ "-" ~ abi_tag ~ "-" ~ platform_tags[target_platform] ~ ".whl" %}
-{% set wheel_artifacts = {
-  "linux-64": {
-    "3.10": {"url": "https://files.pythonhosted.org/packages/e6/c8/6061e330e0df7b0ad5b87ab3ec0ac15b74e157fbd9ea1de056c960596186/xbbg-1.2.4-cp310-cp310-manylinux_2_34_x86_64.whl", "sha256": "003a800a80484c84c868f24febef23b2789284483f4fc99d0314a4a0762fd234"},
-    "3.11": {"url": "https://files.pythonhosted.org/packages/8a/26/67250f82aa9dfdc8e56b8917383ccb0a7660f464c4c8bb1a84cb0ffac1c9/xbbg-1.2.4-cp311-cp311-manylinux_2_34_x86_64.whl", "sha256": "d0f38e5c94b5c44653eafd3846a5c210418cc7dc25b5c0ea9dae96d4f184919c"},
-    "3.12": {"url": "https://files.pythonhosted.org/packages/90/16/613ac30cf770307b014d39e08be2d20f9ebd8824e772767424cb1348fcb6/xbbg-1.2.4-cp312-cp312-manylinux_2_34_x86_64.whl", "sha256": "7ceadd8bf8c8833b9adfd8edd580973535eb14540035425fc71410640af0d5f6"},
-    "3.13": {"url": "https://files.pythonhosted.org/packages/48/57/c343ccf832d4b705c2b383ece2ad2a826fbbc820c53f8f6dfaf89dd05200/xbbg-1.2.4-cp313-cp313-manylinux_2_34_x86_64.whl", "sha256": "436499181f0bdd94231c53a71c4b4368b526f06a02609cfef9def3d6d83c311e"},
-    "3.14": {"url": "https://files.pythonhosted.org/packages/71/41/db689295da3cf8b667139ff7a3e35748cb0478548207c46afbc4c2cb9477/xbbg-1.2.4-cp314-cp314-manylinux_2_34_x86_64.whl", "sha256": "b96041a28b1b51163b6d67962189ddd124111ad594ab9abab4b95f3010d7183b"},
-  },
-  "osx-arm64": {
-    "3.10": {"url": "https://files.pythonhosted.org/packages/a0/21/0c087fbd4c73752e501ab39a0066e7413fc260eab975c9185f79053f0141/xbbg-1.2.4-cp310-cp310-macosx_11_0_universal2.whl", "sha256": "3669d3a9d09874f774cec62a4f576d81ea7741fecddc33fdfc322836b1c5b44e"},
-    "3.11": {"url": "https://files.pythonhosted.org/packages/0b/d7/bae2b1e47fa403f26a071ace566b8ed5c460638145c5e77cc2cd9355d06e/xbbg-1.2.4-cp311-cp311-macosx_11_0_universal2.whl", "sha256": "e670b6c8d05468a1d4a9c0e6c7401499b03f29b2b3c2442898e61468d4ee1d4f"},
-    "3.12": {"url": "https://files.pythonhosted.org/packages/eb/db/88ef0270d12630653e661bb383d113c73b6c0d9e2f5d9be3f2873bcf0b0e/xbbg-1.2.4-cp312-cp312-macosx_11_0_universal2.whl", "sha256": "44d5514db7bc8d2da14fb51b9a297429f8afd4c66892414ca59c79b344d97932"},
-    "3.13": {"url": "https://files.pythonhosted.org/packages/a0/62/ab302aa8510fb2dbee4fffc360e5fb1624ca138447f658dc263cc6109917/xbbg-1.2.4-cp313-cp313-macosx_11_0_universal2.whl", "sha256": "a499df76ba6164753fc1432db0f95232f375a7073415817b1e185f3eea33c55b"},
-    "3.14": {"url": "https://files.pythonhosted.org/packages/25/17/f0ffdca0e390f3cfc95637675b627ef4bf28a5cfc0c1a566c7cc5497e384/xbbg-1.2.4-cp314-cp314-macosx_11_0_universal2.whl", "sha256": "4951ab50a5782baad3b14ff5936c86e5d1ae415519c360d4033356ce1490c368"},
-  },
-  "win-64": {
-    "3.10": {"url": "https://files.pythonhosted.org/packages/1d/9b/9bf10e747dff7d7b8210b516feab69ddff50fe157385a05b5b2e31e3c150/xbbg-1.2.4-cp310-cp310-win_amd64.whl", "sha256": "d04b89ab2b627d06fbbad68987f04badd9351a678bc65bf8524816e280731ebc"},
-    "3.11": {"url": "https://files.pythonhosted.org/packages/3e/18/61dec4dd7681ee0447738300564a43e7e84362f4e02895927b1508e716c5/xbbg-1.2.4-cp311-cp311-win_amd64.whl", "sha256": "f2a8754fe8469b1bb6c5262a93bd6f20c86e0c05708c8fa8fa3a60a0686c6fe3"},
-    "3.12": {"url": "https://files.pythonhosted.org/packages/a0/46/144d3d0200a2c971153d5e5f51eea8d03535fc4fdb4572ba420091f429c3/xbbg-1.2.4-cp312-cp312-win_amd64.whl", "sha256": "01fb8651963df18b5b3768b036d3c47bbff3c54520ad4a8e00e4bd983e117f9c"},
-    "3.13": {"url": "https://files.pythonhosted.org/packages/01/df/25d2453045da2652998004d1d65b720791b925bbc7c8da65ec7cc074e703/xbbg-1.2.4-cp313-cp313-win_amd64.whl", "sha256": "f0054759a23ec90d7208c3156d10d4d758670584e46c9dee0fbfd2062e6d7801"},
-    "3.14": {"url": "https://files.pythonhosted.org/packages/ae/18/e69f938b299368c6be2b67708ebcc427b4e4841a55ce98168c66a36a49fe/xbbg-1.2.4-cp314-cp314-win_amd64.whl", "sha256": "87418d2da6ca5ff42a68f3eff483864f1f2b48881bb782ceca443d4480ef925a"},
-  },
-} %}
-{% set wheel = wheel_artifacts[target_platform][python_mm] %}
+{% set version = "1.3.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  # Keep the sdist for metadata/license capture, and package the matching upstream wheel locally.
-  - url: https://files.pythonhosted.org/packages/05/83/5112db81acd8b5b9e3a93fcd08524d7388a5be015fdc993b467a2cccea09/xbbg-1.2.4.tar.gz
-    sha256: 0a8f7c7768b119dd31b77b31e8b4d1adc7cd4a69b8e60c518d8b93807980f728
-    folder: sdist
-  - url: {{ wheel["url"] }}
-    sha256: {{ wheel["sha256"] }}
-    fn: {{ wheel_filename }}
+  url: https://github.com/xbbg-org/xbbg/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 382292e2ff96101de84d2f529c30414e4c536a4cfb041da822adfc7b7494db93
 
 build:
-  number: 2
+  number: 0
   skip: true  # [py<310 or py>=315 or (osx and x86_64)]
   script:
-    - export PIP_NO_INDEX=false                                                                                                # [unix]
-    - set PIP_NO_INDEX=false                                                                                                   # [win]
-    # Package the verified wheel artifact locally while preserving the matrix interpreter.
-    - {{ PYTHON }} -m pip install ./{{ wheel_filename }} --no-deps --no-cache-dir -vv
+    - export BLPAPI_INCLUDE_DIR="${PREFIX}/include"  # [unix]
+    - export BLPAPI_LIB_DIR="${PREFIX}/lib"  # [unix]
+    - export LIBCLANG_PATH="${BUILD_PREFIX}/lib"  # [unix]
+    - export SETUPTOOLS_SCM_PRETEND_VERSION="{{ version }}"  # [unix]
+    - set "BLPAPI_INCLUDE_DIR=%LIBRARY_INC%"  # [win]
+    - set "BLPAPI_LIB_DIR=%LIBRARY_LIB%"  # [win]
+    - set "LIBCLANG_PATH=%BUILD_PREFIX%\Library\bin"  # [win]
+    - set "SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}"  # [win]
+    - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+    - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vv
 
 requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('rust') }}
+    - {{ stdlib('c') }}
+    - cargo-bundle-licenses
+    - clangdev  # [unix]
+    - libclang  # [win]
   host:
     - python
     - pip
+    - setuptools >=82
+    - setuptools-rust >=1.12
+    - setuptools-scm >=9
+    - wheel >=0.46
+    - libblpapi-devel
   run:
     - python
     - narwhals >=2.0
     - blpapi
+    - libblpapi
 
 test:
   imports:
@@ -71,7 +56,9 @@ about:
   home: https://xbbg.org/
   license: Apache-2.0
   license_family: Apache
-  license_file: sdist/LICENSE
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
   summary: Independent Bloomberg BLPAPI client for Python data workflows
   description: |
     xbbg is an independent Bloomberg BLPAPI client for authorized Bloomberg
@@ -83,10 +70,9 @@ about:
     osx-arm64, and win-64 on Python 3.10 through 3.14; older noarch entries on
     anaconda.org are historical v0.x builds.
   doc_url: https://xbbg.org/
-  dev_url: https://github.com/alpha-xone/xbbg
+  dev_url: https://github.com/xbbg-org/xbbg
 
 extra:
   recipe-maintainers:
     - m3ridian-zero
-    - kj55-dev
     - makoponi


### PR DESCRIPTION
## Summary
- build xbbg from the tagged GitHub source archive instead of vendoring every upstream wheel URL/checksum
- use PyPI as the conda-forge bot version-detection source so JS-only GitHub releases cannot confuse Python package updates
- add Rust/Bloomberg SDK build dependencies and explicit libblpapi runtime dependency
- remove the invalid maintainer entry that made recipe lint fail
- rerender with conda-smithy 2026.6.14 and conda-forge-pinning 2026.06.24.14.56.59

## Validation
- pixi exec conda-smithy recipe-lint --conda-forge .
- pixi exec conda-build recipe --variant-config-files .ci_support/win_64_python3.14.____cp314.yaml -c conda-forge