### PR TITLE
Update xbbg to 1.4.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "xbbg" %}
-{% set version = "1.3.1" %}
+{% set version = "1.4.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/xbbg-org/xbbg/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 382292e2ff96101de84d2f529c30414e4c536a4cfb041da822adfc7b7494db93
+  sha256: 51947bde00cf7ab2fe7170cd89f3323f014c30cb220e8496cfcb1acb4eb0be6b
 
 build:
   number: 0


### PR DESCRIPTION
## Summary
- update xbbg recipe from 1.3.1 to 1.4.1
- update the GitHub tag archive sha256 for v1.4.1
- keep build number at 0 for the new upstream release

## Validation
- pixi exec conda-smithy recipe-lint --conda-forge .
- pixi exec conda-build recipe --variant-config-files .ci_support/win_64_python3.14.____cp314.yaml -c conda-forge

## Notes
- Closed stale draft PR #33 before opening this current update.